### PR TITLE
baseapp,store: fix rollback to previous versions

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -142,6 +142,11 @@ func (app *BaseApp) Logger() log.Logger {
 	return app.logger
 }
 
+// GetCommitMultiStore returns the underlying CommitMultiStore
+func (app *BaseApp) GetCommitMultiStore() sdk.CommitMultiStore {
+	return app.cms
+}
+
 // SetCommitMultiStoreTracer sets the store tracer on the BaseApp's underlying
 // CommitMultiStore.
 func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/tendermint/tendermint => github.com/maticnetwork/tendermint v0.33.2
+replace github.com/tendermint/tendermint => github.com/maticnetwork/tendermint v0.33.3
 
 replace github.com/tendermint/tm-db => github.com/tendermint/tm-db v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1244,8 +1244,8 @@ github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamh
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/maticnetwork/tendermint v0.33.2 h1:R9M7jgAmON8K/LbzMvtWPDhtPkNcqzkUUHp1ict/h3s=
-github.com/maticnetwork/tendermint v0.33.2/go.mod h1:D2fcnxGk6bje+LoPwImuKSSYLiK7/G06IynGNDSEcJk=
+github.com/maticnetwork/tendermint v0.33.3 h1:s1/Ubxh7Axv2bClr+aFMWNn5qzbRKEHEw/uEVxLTc0I=
+github.com/maticnetwork/tendermint v0.33.3/go.mod h1:D2fcnxGk6bje+LoPwImuKSSYLiK7/G06IynGNDSEcJk=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -111,6 +111,15 @@ func (st *Store) DeleteVersions(versions ...int64) error {
 	return nil
 }
 
+// LoadVersionForOverwriting deletes data from targetVersion + 1 onward
+func (st *Store) LoadVersionForOverwriting(targetVersion int64) (int64, error) {
+	mutTree, ok := st.tree.(*iavl.MutableTree)
+	if !ok {
+		return st.tree.Version(), fmt.Errorf("not of type mutable tree")
+	}
+	return mutTree.LoadVersionForOverwriting(targetVersion)
+}
+
 // Implements Committer.
 func (st *Store) Commit() types.CommitID {
 	// Save a new version.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -59,23 +59,27 @@ func NewStore(db dbm.DB) *Store {
 }
 
 // RollbackToVersion delete the versions after `target` and update the latest version.
-func (rs *Store) RollbackToVersion(target int64) int64 {
-	if target < 0 {
-		panic("Negative rollback target")
+func (rs *Store) RollbackToVersion(target int64) error {
+	if target <= 0 {
+		return fmt.Errorf("invalid rollback height target: %d", target)
 	}
-	current := getLatestVersion(rs.db)
-	if target >= current {
-		return current
+
+	for key, store := range rs.stores {
+		if store.GetStoreType() == types.StoreTypeIAVL {
+			// If the store is wrapped with an inter-block cache, we must first unwrap
+			// it to get the underlying IAVL store.
+			store = rs.GetCommitKVStore(key)
+			_, err := store.(*iavl.Store).LoadVersionForOverwriting(target)
+			if err != nil {
+				return err
+			}
+		}
 	}
-	for ; current > target; current-- {
-		rs.pruneHeights = append(rs.pruneHeights, current)
-	}
-	rs.pruneStores()
 
 	// update latest height
-	latestBytes, _ := cdc.MarshalBinaryLengthPrefixed(current)
+	latestBytes, _ := cdc.MarshalBinaryLengthPrefixed(target)
 	rs.db.Set([]byte(latestVersionKey), latestBytes)
-	return current
+	return rs.LoadLatestVersion()
 }
 
 // pruneStores will batch delete a list of heights from each mounted sub-store.


### PR DESCRIPTION
Relates to maticnetwork/tendermint#34

This PR fixes rollback of the application state by correctly removing specified versions from the store. Please note that this functionality isn't thoroughly tested for various scenarios but should help in recovering a corrupt application state. 