### PR TITLE
Fix: add version for abci_info endpoint

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -375,6 +375,7 @@ func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
 		Data:             app.name,
 		LastBlockHeight:  lastCommitID.Version,
 		LastBlockAppHash: lastCommitID.Hash,
+		Version:          app.AppVersion(),
 	}
 }
 


### PR DESCRIPTION
This PR adds the missing `version` field on `ResponseInfo` for the `/abci_info` endpoint.

This field (version) is useful for monitoring that all nodes are running the same version, which helps with automatic upgrades.


The new abci_info endpoint looks like this: 
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "response": {
      "data": "Heimdall",
      "version": "1.2.3",
      "last_block_height": "34",
      "last_block_app_hash": "HhAiY2ecdj/P1JWPXFReNJDn8TLxWaKyJL3o3nAolVQ="
    }
  }
}
```
